### PR TITLE
testcontainers example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,16 +34,21 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.springframework.session:spring-session-core'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-    implementation 'org.testng:testng:7.1.0'
+    implementation 'org.testng:testng:7.7.0'
     compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:postgresql'
+	testImplementation 'io.rest-assured:rest-assured'
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.3.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0'
+
 }
 
 tasks.named('test') {

--- a/src/test/java/ua/goit/ShortenerApplicationTests.java
+++ b/src/test/java/ua/goit/ShortenerApplicationTests.java
@@ -3,11 +3,21 @@ package ua.goit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import ua.goit.url.UrlController;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@SpringBootTest
-class ShortenerApplicationTests {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+public class ShortenerApplicationTests {
+	@Container
+	@ServiceConnection
+	static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:latest");
+
 	@Autowired
 	private UrlController controller;
 

--- a/src/test/java/ua/goit/url/service/ShortLinkGeneratorTest.java
+++ b/src/test/java/ua/goit/url/service/ShortLinkGeneratorTest.java
@@ -49,7 +49,7 @@ public class ShortLinkGeneratorTest {
 
         Mockito.when(urlService.listAll()).thenReturn(mockUrls);
 
-        ShortLinkGenerator shortLinkGenerator = new ShortLinkGenerator(urlService);
+        ShortLinkGenerator shortLinkGenerator = new ShortLinkGenerator();
 
         String generatedLink = shortLinkGenerator.generateShortLink();
 

--- a/src/test/java/ua/goit/url/service/UrlRepositoryTest.java
+++ b/src/test/java/ua/goit/url/service/UrlRepositoryTest.java
@@ -1,0 +1,34 @@
+package ua.goit.url.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import ua.goit.url.UrlEntity;
+import ua.goit.url.repository.UrlRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+public class UrlRepositoryTest {
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:latest");
+
+    @Autowired
+    UrlRepository urlRepository;
+
+    @Test
+    void UrlRepositoryIsNotEmpty(){
+        List<UrlEntity> list = urlRepository.findAll();
+        assertNotNull( list.size());
+    }
+}

--- a/src/test/resources/db/migration/V2__populate.sql
+++ b/src/test/resources/db/migration/V2__populate.sql
@@ -1,0 +1,5 @@
+INSERT INTO users (username, password, role)
+VALUES ('testuser', 'password', 'USER');
+
+INSERT INTO urls (short_url, url, description, created_date, expiration_date, visit_count)
+VALUES ('testurl', 'https://some_long_named_portal.com/', 'for test only', '2024-01-18 12:34:56','2024-02-18 12:34:56', 1);


### PR DESCRIPTION
Наче розібрався з тесконтейнерами. Як приклад - UrlRepositoryTest. Саме в спрінгу з версії 3.1.0 покращілась підтримка тестконтейнерів і з'явилася можливість максимально просто зарееструвати з'єднання з бд

@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@Testcontainers
public class SomeClassTest {
    @Container
    @ServiceConnection
    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:latest");
    @Test
    void test() {
      ...
    }
}

Не потрібні моки, тести пишуться як на робочу базу, але вона в контейнері (то видно по логах). Контейнер існує лише поки ідуть тести. Найкраще що я знайшов https://github.com/testcontainers/testcontainers-java-spring-boot-quickstart